### PR TITLE
add generick script required to build bootstrap

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 build
 -----
 
+cp generic /usr/share/debootstrap/scripts/
 export RELEASE=debian/::CODENAME::
 make clean
 make

--- a/generic
+++ b/generic
@@ -1,0 +1,202 @@
+# package: debootstrap (1.0.20ubuntu1)
+# used by: fab/bootstraps
+
+case $ARCH in
+  amd64|i386)
+    default_mirror http://archive.ubuntu.com/ubuntu
+    ;;
+  sparc)
+    case $SUITE in
+      gutsy)
+	default_mirror http://archive.ubuntu.com/ubuntu
+	;;
+      *)
+	default_mirror http://ports.ubuntu.com/ubuntu-ports
+	;;
+    esac
+    ;;
+  *)
+    default_mirror http://ports.ubuntu.com/ubuntu-ports
+    ;;
+esac
+mirror_style release
+download_style apt
+finddebs_style from-indices
+variants - buildd fakechroot minbase
+
+if doing_variant fakechroot; then
+    test "$FAKECHROOT" = "true" || error 1 FAKECHROOTREQ "This variant requires fakechroot environment to be started"
+fi
+
+case $ARCH in
+  alpha|ia64) LIBC="libc6.1" ;;
+  *)          LIBC="libc6" ;;
+esac
+
+work_out_debs () {
+    required=$REQUIRED_PACKAGES
+    base=$BASE_PACKAGES
+}
+
+first_stage_install () {
+    extract $required
+
+    mkdir -p "$TARGET/var/lib/dpkg"
+    : >"$TARGET/var/lib/dpkg/status"
+    : >"$TARGET/var/lib/dpkg/available"
+
+    setup_etc
+    if [ ! -e "$TARGET/etc/fstab" ]; then
+        echo '# UNCONFIGURED FSTAB FOR BASE SYSTEM' > "$TARGET/etc/fstab"
+        chown 0:0 "$TARGET/etc/fstab"; chmod 644 "$TARGET/etc/fstab"
+    fi
+
+    if doing_variant fakechroot; then
+        setup_devices_fakechroot
+    else
+        setup_devices
+    fi
+
+    x_feign_install () {
+        local pkg="$1"
+        local deb="$(debfor $pkg)"
+        local ver="$(
+            ar -p "$TARGET/$deb" control.tar.gz | zcat |
+                tar -O -xf - control ./control 2>/dev/null |
+                grep -i ^Version: | sed -e 's/[^:]*: *//' | head -n 1
+        )"
+
+        mkdir -p "$TARGET/var/lib/dpkg/info"
+
+        echo \
+"Package: $pkg
+Version: $ver
+Status: install ok installed" >> "$TARGET/var/lib/dpkg/status"
+
+        touch "$TARGET/var/lib/dpkg/info/${pkg}.list"
+    }
+
+    x_feign_install dpkg
+}
+
+second_stage_install () {
+    x_core_install () {
+	smallyes '' | in_target dpkg --force-depends --install $(debfor "$@")
+    }
+
+    p () {
+	baseprog="$(($baseprog + ${1:-1}))"
+    }
+
+    if doing_variant fakechroot; then
+	setup_proc_fakechroot
+    else
+	setup_proc
+	in_target /sbin/ldconfig
+    fi
+
+    DEBIAN_FRONTEND=noninteractive
+    DEBCONF_NONINTERACTIVE_SEEN=true
+    export DEBIAN_FRONTEND DEBCONF_NONINTERACTIVE_SEEN
+
+    baseprog=0
+    bases=7
+
+    p; progress $baseprog $bases INSTCORE "Installing core packages" #1
+    info INSTCORE "Installing core packages..."
+
+    p; progress $baseprog $bases INSTCORE "Installing core packages" #2
+    ln -sf mawk "$TARGET/usr/bin/awk"
+    x_core_install base-passwd
+    x_core_install base-files
+    p; progress $baseprog $bases INSTCORE "Installing core packages" #3
+    x_core_install dpkg
+
+    if [ ! -e "$TARGET/etc/localtime" ]; then
+        ln -sf /usr/share/zoneinfo/Etc/UTC "$TARGET/etc/localtime"
+    fi
+
+    if doing_variant fakechroot; then 
+	install_fakechroot_tools
+    fi
+
+    p; progress $baseprog $bases INSTCORE "Installing core packages" #4
+    x_core_install $LIBC
+
+    p; progress $baseprog $bases INSTCORE "Installing core packages" #5
+    x_core_install perl-base
+
+    p; progress $baseprog $bases INSTCORE "Installing core packages" #6
+    rm "$TARGET/usr/bin/awk"
+    x_core_install mawk
+
+    p; progress $baseprog $bases INSTCORE "Installing core packages" #7
+    if doing_variant -; then
+      x_core_install debconf
+    fi
+
+    baseprog=0
+    bases=$(set -- $required; echo $#)
+
+    info UNPACKREQ "Unpacking required packages..."
+
+    smallyes '' | 
+      (repeatn 5 in_target_failmsg UNPACK_REQ_FAIL_FIVE "Failure while unpacking required packages.  This will be attempted up to five times." "" \
+      dpkg --status-fd 8 --force-depends --unpack $(debfor $required) 8>&1 1>&7 |
+      dpkg_progress $baseprog $bases UNPACKREQ "Unpacking required packages" UNPACKING) 7>&1
+
+    info CONFREQ "Configuring required packages..."
+
+    if doing_variant fakechroot; then
+	# fix initscripts postinst (no mounting possible, and wrong if condition)
+	sed -i '/dpkg.*--compare-versions/ s/\<lt\>/lt-nl/' "$TARGET/var/lib/dpkg/info/initscripts.postinst"
+    fi
+
+    mv "$TARGET/sbin/start-stop-daemon" "$TARGET/sbin/start-stop-daemon.REAL"
+    echo \
+"#!/bin/sh
+echo
+echo \"Warning: Fake start-stop-daemon called, doing nothing\"" > "$TARGET/sbin/start-stop-daemon"
+    chmod 755 "$TARGET/sbin/start-stop-daemon"
+
+    if [ -x "$TARGET/sbin/initctl" ]; then
+      mv "$TARGET/sbin/initctl" "$TARGET/sbin/initctl.REAL"
+      echo \
+"#!/bin/sh
+echo
+echo \"Warning: Fake initctl called, doing nothing\"" > "$TARGET/sbin/initctl"
+      chmod 755 "$TARGET/sbin/initctl"
+    fi
+
+    setup_dselect_method apt
+
+    smallyes '' | 
+      (in_target_failmsg CONF_REQ_FAIL "Failure while configuring required packages." "" \
+      dpkg --status-fd 8 --configure --pending --force-configure-any --force-depends 8>&1 1>&7 |
+      dpkg_progress $baseprog $bases CONFREQ "Configuring required packages" CONFIGURING) 7>&1
+
+    baseprog=0
+    bases="$(set -- $base; echo $#)"
+
+    info UNPACKBASE "Unpacking the base system..."
+
+    smallyes '' | 
+      (repeatn 5 in_target_failmsg INST_BASE_FAIL_FIVE "Failure while installing base packages.  This will be re-attempted up to five times." "" \
+      dpkg --status-fd 8 --force-overwrite --force-confold --skip-same-version --unpack $(debfor $base) 8>&1 1>&7 |
+      dpkg_progress $baseprog $bases UNPACKBASE "Unpacking base system" UNPACKING) 7>&1
+
+    info CONFBASE "Configuring the base system..."
+
+    smallyes '' |
+      (repeatn 5 in_target_failmsg CONF_BASE_FAIL_FIVE "Failure while configuring base packages.  This will be attempted 5 times." "" \
+      dpkg --status-fd 8 --force-confold --skip-same-version --configure -a 8>&1 1>&7 |
+      dpkg_progress $baseprog $bases CONFBASE "Configuring base system" CONFIGURING) 7>&1
+
+    if [ -x "$TARGET/sbin/initctl.REAL" ]; then
+      mv "$TARGET/sbin/initctl.REAL" "$TARGET/sbin/initctl"
+    fi
+    mv "$TARGET/sbin/start-stop-daemon.REAL" "$TARGET/sbin/start-stop-daemon"
+
+    progress $bases $bases CONFBASE "Configuring base system"
+    info BASESUCCESS "Base system installed successfully."
+}


### PR DESCRIPTION
closes https://github.com/turnkeylinux/tracker/issues/600

The "generic" script is required to build a bootstrap. It was missing; but now it's not! :smile: 

There are possibly other missing components though so ideally we probably should provide a tweaked tkldev that includes all of this stuff!
