### PR TITLE
Add zstd so that it can be used for initramfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CODENAME ?= $(shell basename $(RELEASE))
 
 MIRROR ?= http://deb.debian.org/debian
 VARIANT ?= minbase
-EXTRA_PKGS ?= initramfs-tools,gpg,gpg-agent,ca-certificates,lsb-release
+EXTRA_PKGS ?= initramfs-tools,gpg,gpg-agent,ca-certificates,lsb-release,zstd
 REMOVELIST ?= ./removelist
 
 # build output path


### PR DESCRIPTION
If `zstd` is installed at build time, zstd compression will be used when generating the initramfs (instead of gzip). It has already been added to the default plan, however including it in the bootstrap makes the initial appliance build step (which installs the kernel and generates initramfs) marginally faster and smaller.

Perhaps a better method would be to provide a dummy update-initramfs script (like Alon & Liraz did many years ago) so the initramfs isn't really generated until later in the build process, however this path is probably less prone to future issues.